### PR TITLE
fix: remove duplicate poster image in hero section

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,7 +1,6 @@
 ---
 import Button from "./ui/Button.astro";
 import heroPoster from "../assets/images/living-room-showcase.jpeg";
-import { Image } from "astro:assets";
 ---
 
 <section
@@ -9,18 +8,7 @@ import { Image } from "astro:assets";
 >
     <!-- Background Video / Image -->
     <div class="absolute inset-0 z-0 select-none">
-        <!-- Poster Image (fallback while video loads) -->
-        <Image
-            src={heroPoster}
-            alt="Luxury modern living room interior with contemporary furniture and ambient lighting"
-            width={1920}
-            height={1080}
-            loading="eager"
-            fetchpriority="high"
-            class="absolute inset-0 w-full h-full object-cover opacity-80"
-        />
-
-        <!-- Video -->
+        <!-- Video with poster fallback -->
         <video
             class="absolute inset-0 w-full h-full object-cover opacity-80"
             autoplay


### PR DESCRIPTION
Removed the redundant Image component that was displaying alongside the video.
The video element already has a poster attribute for fallback display, so the
duplicate Image component was unnecessary, wasted resources, and caused visual overlap.

This eliminates resource loading waste and fixes the visual overlap issue while
maintaining the same fallback experience using the native video poster attribute.

Closes #8

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
