### PR TITLE
chore(release): disable auto-merge for release-please PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,3 @@ jobs:
         with:
           release-type: simple
           token: ${{ secrets.RELEASE_PAT }}
-
-      - name: Auto-merge Release PR
-        if: steps.release.outputs.pr
-        run: |
-          PR_NUMBER=$(echo '${{ steps.release.outputs.pr }}' | jq -r '.number')
-          gh pr merge "$PR_NUMBER" --squash
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "release-type": "simple",
+  "autoMerge": false,
   "packages": {
     ".": {}
   }


### PR DESCRIPTION
Removed automatic merging of release PRs from the workflow and added explicit
autoMerge: false configuration. This ensures all release PRs require manual
review and approval before merging to main, allowing better control over version releases.

Changes:
- Removed auto-merge step from release.yml workflow
- Added "autoMerge": false to release-please-config.json

This prevents unexpected automatic releases and ensures all version bumps and
changelog updates are manually reviewed before deployment.

Closes #13

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
