### PR TITLE
fix: add fluid viewport scaling

### DIFF
--- a/src/components/CtaSection.astro
+++ b/src/components/CtaSection.astro
@@ -89,7 +89,7 @@ const displayHeading = endsWithQuestion ? heading.slice(0, -1) : heading;
     position: relative;
     z-index: 2;
     padding-inline: clamp(1.5rem, 5vw, 5rem);
-    max-width: 680px;
+    max-width: 42.5rem;
     margin-inline: auto;
   }
   .overline {

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -58,7 +58,7 @@ import Footer from '../components/Footer.astro';
     z-index: 2;
     padding: clamp(2rem, 5vw, 4rem) clamp(1.5rem, 5vw, 5rem);
     padding-top: 8rem;
-    max-width: 600px;
+    max-width: 37.5rem;
   }
   .not-found-h1 {
     font-family: var(--font-heading);

--- a/src/pages/contact/index.astro
+++ b/src/pages/contact/index.astro
@@ -130,7 +130,7 @@ import mapTiel from '../../assets/media/map-tiel.webp';
   .page-hero-content {
     padding: clamp(2rem, 5vw, 4rem) clamp(1.5rem, 5vw, 5rem);
     padding-top: 8rem;
-    max-width: 600px;
+    max-width: 37.5rem;
   }
   .page-hero-h1 {
     font-family: var(--font-heading);

--- a/src/pages/cookie-statement/index.astro
+++ b/src/pages/cookie-statement/index.astro
@@ -64,7 +64,7 @@ import Footer from '../../components/Footer.astro';
     padding: clamp(2rem, 5vw, 4rem) clamp(1.5rem, 5vw, 5rem);
     padding-top: 7rem;
   }
-  .legal-hero-content { max-width: 700px; }
+  .legal-hero-content { max-width: 43.75rem; }
   .legal-h1 {
     font-family: var(--font-heading);
     font-size: clamp(2rem, 1.5rem + 2.5vw, 3.5rem);

--- a/src/pages/faq/index.astro
+++ b/src/pages/faq/index.astro
@@ -124,7 +124,7 @@ const faqs = [
   .page-hero-content {
     padding: clamp(2rem, 5vw, 4rem) clamp(1.5rem, 5vw, 5rem);
     padding-top: 8rem;
-    max-width: 600px;
+    max-width: 37.5rem;
   }
   .page-hero-h1 {
     font-family: var(--font-heading);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -396,10 +396,14 @@ const testimonials = [
   }
   .hero-content {
     position: absolute;
+    top: 5rem;
     bottom: clamp(3rem, 8vh, 5.5rem);
     left: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
     padding-inline: clamp(1.5rem, 5vw, 6rem);
-    max-width: 700px;
+    max-width: 43.75rem;
     z-index: 2;
   }
   .hero-overline {
@@ -422,7 +426,7 @@ const testimonials = [
     font-weight: 300;
     line-height: 1.68;
     color: var(--color-text-muted-dark);
-    max-width: 400px;
+    max-width: 25rem;
     margin-bottom: 2.5rem;
   }
   .hero-cta {
@@ -695,7 +699,7 @@ const testimonials = [
     line-height: 1.18;
     letter-spacing: -0.015em;
     color: var(--color-text);
-    max-width: 500px;
+    max-width: 31.25rem;
   }
   .process-steps {
     display: grid;
@@ -792,7 +796,7 @@ const testimonials = [
     letter-spacing: 0.01em;
     color: var(--color-text-on-dark);
     line-height: 1.2;
-    max-width: 400px;
+    max-width: 25rem;
   }
   .showroom-link { text-decoration: none; }
 
@@ -808,7 +812,7 @@ const testimonials = [
     }
     .about-inner {
       grid-template-columns: 1fr;
-      max-width: 680px;
+      max-width: 42.5rem;
     }
     .about-portrait { aspect-ratio: 4/3; }
   }

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -95,7 +95,7 @@ const projects = [
   .page-hero-content {
     padding: clamp(2rem, 5vw, 4rem) clamp(1.5rem, 5vw, 5rem);
     padding-top: 8rem;
-    max-width: 650px;
+    max-width: 40.625rem;
   }
   .page-hero-h1 {
     font-family: var(--font-heading);

--- a/src/pages/services/3d-design/index.astro
+++ b/src/pages/services/3d-design/index.astro
@@ -179,7 +179,7 @@ const serviceFaqs = [
   .page-hero-content {
     padding: clamp(2rem, 5vw, 4rem) clamp(1.5rem, 5vw, 5rem);
     padding-top: 8rem;
-    max-width: 700px;
+    max-width: 43.75rem;
   }
   .page-hero-h1 {
     font-family: var(--font-heading);

--- a/src/pages/services/index.astro
+++ b/src/pages/services/index.astro
@@ -192,7 +192,7 @@ const serviceFaqs = [
   .page-hero-content {
     padding: clamp(2rem, 5vw, 4rem) clamp(1.5rem, 5vw, 5rem);
     padding-top: 8rem;
-    max-width: 700px;
+    max-width: 43.75rem;
   }
   .page-hero-h1 {
     font-family: var(--font-heading);

--- a/src/pages/werkgebied/[city].astro
+++ b/src/pages/werkgebied/[city].astro
@@ -457,7 +457,7 @@ const pageDescription = isInternational
   left: 0;
   padding-inline-start: clamp(1.5rem, 5vw, 6rem);
   padding-inline-end: clamp(1.5rem, 5vw, 6rem);
-  max-width: 720px;
+  max-width: 45rem;
   z-index: 2;
 }
 
@@ -488,7 +488,7 @@ const pageDescription = isInternational
   font-weight: 300;
   line-height: 1.68;
   color: var(--color-text-muted-dark);
-  max-width: 440px;
+  max-width: 27.5rem;
 }
 
 /* ── BREADCRUMB BAR ───────────────────────────────────────────────────── */
@@ -718,7 +718,7 @@ const pageDescription = isInternational
   border-radius: 2px;
   cursor: pointer;
   display: block;
-  max-width: 860px;
+  max-width: 53.75rem;
   text-decoration: none;
 }
 
@@ -772,7 +772,7 @@ const pageDescription = isInternational
 
 .loc-faq-inner {
   padding-inline: clamp(1.5rem, 5vw, 6rem);
-  max-width: 860px;
+  max-width: 53.75rem;
 }
 
 .loc-faq-header {
@@ -897,7 +897,7 @@ const pageDescription = isInternational
   .loc-intro-inner,
   .loc-services-inner {
     grid-template-columns: 1fr;
-    max-width: 720px;
+    max-width: 45rem;
   }
   .loc-facts { margin-top: 0; }
 }

--- a/src/pages/werkgebied/index.astro
+++ b/src/pages/werkgebied/index.astro
@@ -174,7 +174,7 @@ const internationalCities = locations.filter((loc) =>
 .page-hero-content {
   position: relative;
   z-index: 2;
-  max-width: 680px;
+  max-width: 42.5rem;
 }
 
 .page-hero-h1 {
@@ -213,7 +213,7 @@ const internationalCities = locations.filter((loc) =>
 
 .cities-header {
   margin-bottom: clamp(3rem, 4vw, 5rem);
-  max-width: 640px;
+  max-width: 40rem;
 }
 
 .cities-h2 {
@@ -250,7 +250,7 @@ const internationalCities = locations.filter((loc) =>
 
 .cities-grid--international {
   grid-template-columns: repeat(2, 1fr);
-  max-width: 720px;
+  max-width: 45rem;
 }
 
 /* City card */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -213,6 +213,11 @@
    ═══════════════════════════════════════════════ */
 
 @layer base {
+  html {
+    font-size: clamp(1rem, 0.68rem + 0.357vw, 1.25rem);
+    /* 16px @ 1440px → ~18px @ 1920px → 20px @ 2560px+ */
+  }
+
   body {
     font-family: var(--font-body);
     font-weight: 300;


### PR DESCRIPTION
## Summary
- Add fluid root font-size `clamp(1rem, 0.68rem + 0.357vw, 1.25rem)` so the entire design scales proportionally on wider monitors (16px@1440px → 20px@2560px)
- Convert all content `max-width` values from `px` to `rem` across 12 files so containers grow with the root font-size
- Add `top` constraint to homepage hero to prevent heading from clipping behind the fixed nav

## Test plan
- [ ] Homepage hero: "Luxury Interiors" heading fully visible below nav on 1920px+ monitors
- [ ] CTA section: "Begin a Conversation" no longer breaks mid-word
- [ ] Service pages: headings don't clip or overflow containers
- [ ] Mobile: no visual regression (fluid root bottoms out at 1rem/16px)
- [ ] 1440px viewport: design looks identical to before (16px base, no change)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)